### PR TITLE
fix: response name & get -> post

### DIFF
--- a/routes/mc/user/link.rb
+++ b/routes/mc/user/link.rb
@@ -19,11 +19,11 @@ class McUserLinkRouter < Base
   # Apple Musicとの連携
   get "/applemusic" do
     access_token = MusicApi::AppleMusicApi.generate_access_token()
-    send_json(developer_token: access_token)
+    send_json(access_token: access_token)
   end
 
   # Apple Music連携後のリダイレクト先
-  get "/applemusic/callback" do
+  post "/applemusic/callback" do
     return bad_request("invalid parameters") unless has_params?(params, [:access_token, :music_user_token])
     @env["user"].access_tokens.find_or_create_by(provider: 'applemusic').update(access_token: params['access_token'], music_user_token: params['music_user_token'])
     send_json(ok: true)


### PR DESCRIPTION
## 修正内容
- link.rbのレスポンス名の変更
developer_token -> access_token

- callbackのHTTP Method変更
get -> post