### PR TITLE
fix spotify top12

### DIFF
--- a/lib/music/implements/spotify_api.rb
+++ b/lib/music/implements/spotify_api.rb
@@ -127,6 +127,27 @@ module MusicApi
       }
     end
 
+    def get_top12(playlist_id)
+      res = @spotify_api.get "playlists/#{playlist_id}/tracks?limit=12"
+      if res.status == 401
+        refresh_access_token
+        res = @spotify_api.get "playlists/#{playlist_id}/tracks?limit=12"
+      end
+      body = JSON.parse(res.body)
+      return nil unless res.status >= 200 && res.status < 300
+      body['items'].map { |item|
+        track = item['track']
+        {
+          id: track['uri'],
+          artists: track['artists'].map { |artist| artist['name'] }.join(', '),
+          album: track['album']['name'],
+          thumbnail: track['album']['images'].first['url'],
+          name: track['name'],
+          duration: (track['duration_ms'] / 1000).ceil,
+        }
+      }
+    end
+
     def create_playlist(name, description)
       id = me()["id"]
       data = {

--- a/routes/room.rb
+++ b/routes/room.rb
@@ -10,14 +10,14 @@ class RoomRouter < Base
     send_json id: @env["room"]["display_id"], name: @env["room"]["name"], description: @env["room"]["description"],room_cooltime: @env["room"]["room_cooltime"]
   end
 
-  #人気top50を取得
+  #人気top12を取得
   get "/:room_id/music/top" do
     case @env["room"].provider
     when 'spotify'
       token = @env["room"].master.access_tokens.find_by(provider: 'spotify')
       return forbidden("provider is not linked") unless token
       spotify = MusicApi::SpotifyApi.new(token.access_token, token.refresh_token)
-      res = spotify.get_playlist_tracks("37i9dQZEVXbKXQ4mDTEBXq")
+      res = spotify.get_top12("37i9dQZEVXbKXQ4mDTEBXq")
       send_json res
     else
       return not_found_error("playlist not found")


### PR DESCRIPTION
Top50をそのまま表示するとユーザーのPCに負荷がかかって重くなりそうとフロント側からFBをもらったので、Top50からがっしーに指定されたTop12に変更しました！（取り急ぎspotifyだけ修正）
確認お願いします！