### PR TITLE
Apple Musicにおいて、Room作成時にplaylist idがnilになる

### DIFF
--- a/routes/mc/room.rb
+++ b/routes/mc/room.rb
@@ -55,7 +55,7 @@ class McRoomRouter < Base
         playlist_id = res['id']
       when 'applemusic'
         res = @env["applemusic"].create_playlist(params[:room_name], params[:description])
-        playlist_id = res['id']
+        playlist_id = res['data'][0]['id']
       end
     end
 


### PR DESCRIPTION
## issue番号

resolve #174 

## やったこと
applemusic において playlist_id の取得方法を修正

## TODO
- [x] Reviewersを設定しました
- [x] Assigneesを設定しました
- [x] issue番号を記載しました