### PR TITLE
Spotify連携解除した際にroom情報が残っていたのを削除されるように

### DIFF
--- a/routes/mc/user/link.rb
+++ b/routes/mc/user/link.rb
@@ -7,7 +7,10 @@ class McUserLinkRouter < Base
 
   #Spotifyの連携解除
   delete "/spotify"do
-    @env["user"].access_tokens.find_or_create_by(provider: 'spotify').delete
+    @env["user"].access_tokens.find_or_create_by(provider: 'spotify').user.rooms.each do |room|
+      room.destroy
+    end
+    @env["user"].access_tokens.find_or_create_by(provider: 'spotify').destroy
     send_json(ok: true)
   end
 


### PR DESCRIPTION
## issue番号

resolve #181

## やったこと
Spotify連携解除した際にroom情報が残っていたのを削除されるように修正しました


## 補足(あれば)

## TODO
- [x] Reviewersを設定しました
- [x] Assigneesを設定しました
- [x] issue番号を記載しました